### PR TITLE
[BGF] miss FracSecond in parse

### DIFF
--- a/time/src/lib.rs
+++ b/time/src/lib.rs
@@ -1802,7 +1802,7 @@ fn parse(
                     std &= stdMask;
                     if std == stdFracSecond0 || std == stdFracSecond9 {
                         // Fractional second in the layout; proceed normally
-                        break;
+                        continue;
                     }
                     // No fractional second in the layout but we have one in the input.
                     let mut n = 2;


### PR DESCRIPTION
Parse返回的结果没有毫秒、微秒的数据

Go标准库上下文中break表示退出switch作用域，重新进入for循环
![image](https://github.com/user-attachments/assets/92663386-0bcb-4936-93bd-4f606fee6888)
在本仓库中break表示退出loop循环，导致后续的字符串没有解析
![image](https://github.com/user-attachments/assets/cc70d6c4-7d14-4e17-9d98-d02999f79999)


